### PR TITLE
Update Emerging Threat's Suricata Link - hpfeeds-support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,9 +29,9 @@ install-rules:
 	install -d "$(e_sysconfrulesdir)"
 if HAVE_FETCH_COMMAND
 if HAVE_WGET_COMMAND
-	$(HAVE_WGET) -qO - https://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
+	$(HAVE_WGET) -qO - https://rules.emergingthreats.net/open/old/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
 else
-	$(HAVE_CURL) -s https://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
+	$(HAVE_CURL) -s https://rules.emergingthreats.net/open/old/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
 endif
 else
 	@echo "UNABLE to load ruleset wget or curl are not installed on system."

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,9 +29,9 @@ install-rules:
 	install -d "$(e_sysconfrulesdir)"
 if HAVE_FETCH_COMMAND
 if HAVE_WGET_COMMAND
-	$(HAVE_WGET) -qO - http://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
+	$(HAVE_WGET) -qO - https://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
 else
-	$(HAVE_CURL) -s http://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
+	$(HAVE_CURL) -s https://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "$(e_sysconfdir)" -f -
 endif
 else
 	@echo "UNABLE to load ruleset wget or curl are not installed on system."


### PR DESCRIPTION
Recreation of #2 on proper branch.

In April 16th 2020 Proofpoint created an "old" folder and placed suricata 2.0 rules in it. Deploying the MHN suricata sensor today will yield the following error:
```
install -d "/opt/suricata/etc/suricata/rules"
/usr/bin/wget -qO - http://rules.emergingthreats.net/open/suricata-2.0/emerging.rules.tar.gz | tar -x -z -C "/opt/suricata/etc/suricata/" -f -

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
Makefile:888: recipe for target 'install-rules' failed
make: *** [install-rules] Error 2
```

Closes pwnlandia/mhn#836 and pwnlandia/mhn#798

This also implements @d1str0's https change.